### PR TITLE
allow EB_ARGS to be specified before @boegelbot

### DIFF
--- a/boegelbot.py
+++ b/boegelbot.py
@@ -489,7 +489,7 @@ def process_notifications(notifications, github, github_user, github_account, re
             if mention_regex.search(comment_txt):
                 print("Found comment including '%s': %s" % (mention_regex.pattern, comment_txt))
 
-                msg = mention_regex.sub('', comment_txt)
+                msg = mention_regex.sub(' ', comment_txt)
 
                 # require that @<host> is included in comment before taking any action
                 if host_regex.search(msg):


### PR DESCRIPTION
with this small change, the following should work:
EB_ARGS="--force --debug" @boegelbot please test @ generoso

currently, this is interpreted by by boegelbot as (note debug and please being attached to each other):
'EB_PR=11189 EB_ARGS="--force --debugplease" /apps/slurm/default/bin/sbatch --job-name test_PR_11189 ~/boegelbot/eb_from_pr_upload_generoso.sh'
see https://github.com/easybuilders/easybuild-easyconfigs/pull/11189