### PR TITLE
Generoso: Place SLURM output in shared project diretory

### DIFF
--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -2,6 +2,7 @@
 #SBATCH --nodes 1
 #SBATCH --ntasks=4
 #SBATCH --time 100:0:0
+#SBATCH --output /project/boegelbot/slurmjobs/slurm-%j.out
 #SBATCH --get-user-env
 
 set -e


### PR DESCRIPTION
Sometimes it might be helpful for the other maintainers if the SLURM job output is accessibly. Therefore it might be a good idea to put the SLURM job output in the group readable project directory.