### PR TITLE
{jsc-zen2} add optarch for Intel compiler

### DIFF
--- a/eb_from_pr_upload_jsc-zen2.sh
+++ b/eb_from_pr_upload_jsc-zen2.sh
@@ -28,6 +28,8 @@ export EASYBUILD_ACCEPT_EULA_FOR='.*'
 
 export EASYBUILD_HOOKS=$HOME/boegelbot/eb_hooks.py
 
+export EASYBUILD_OPTARCH='Intel:march=core-avx2'
+
 export EASYBUILD_CUDA_COMPUTE_CAPABILITIES=7.0
 
 export EASYBUILD_SET_GID_BIT=1


### PR DESCRIPTION
The option `--optarch=Intel:march=core-avx2` is required on AMD to build some modules correctly.

C.f.
https://github.com/easybuilders/easybuild-easyconfigs/pull/14427#issuecomment-979411224

https://github.com/easybuilders/easybuild-easyconfigs/pull/14841#issuecomment-1021517270