### PR TITLE
Allow @jfgrimm to request test reports from boegelbot

### DIFF
--- a/boegelbot.py
+++ b/boegelbot.py
@@ -516,8 +516,8 @@ def process_notifications(notifications, github, github_user, github_account, re
                     print("Comment includes '%s', so processing it..." % host_regex.pattern)
 
                     maintainers = ['akesandgren', 'bartoldeman', 'bedroge', 'boegel', 'branfosj', 'casparvl',
-                                   'lexming', 'Micket', 'migueldiascosta', 'ocaisa', 'SebastianAchilles', 'smoors',
-                                   'verdurin', 'jfgrimm']
+                                   'jfgrimm', 'lexming', 'Micket', 'migueldiascosta', 'ocaisa', 'SebastianAchilles',
+                                   'smoors', 'verdurin']
                     contributors = ['robert-mijakovic']
                     allowed_accounts = maintainers + contributors
 

--- a/boegelbot.py
+++ b/boegelbot.py
@@ -517,7 +517,7 @@ def process_notifications(notifications, github, github_user, github_account, re
 
                     maintainers = ['akesandgren', 'bartoldeman', 'bedroge', 'boegel', 'branfosj', 'casparvl',
                                    'lexming', 'Micket', 'migueldiascosta', 'ocaisa', 'SebastianAchilles', 'smoors',
-                                   'verdurin']
+                                   'verdurin', 'jfgrimm']
                     contributors = ['robert-mijakovic']
                     allowed_accounts = maintainers + contributors
 


### PR DESCRIPTION
This MR adds @jfgrimm to list of maintainers that are allowed to request test reports from boegelbot.