### PR TITLE
Allow execution on multiple hosts

### DIFF
--- a/boegelbot.py
+++ b/boegelbot.py
@@ -486,7 +486,7 @@ def process_notifications(notifications, github, github_user, github_account, re
                 trigger_comment_id = comment_id
                 break
 
-        check_str = "notification for comment with ID %s processed" % trigger_comment_id
+        check_str = "notification for comment with ID %s processed on %s" % (trigger_comment_id, host)
 
         processed = False
         for comment_data in comments_data[::-1]:


### PR DESCRIPTION
This PR should allow the execution on multiple hosts by making the `check_str` unique per `host`. For example

```
@boegelbot please test @ generoso jsc-zen2
```

should become possible with the PR.

However I am not sure if this PR would trigger re-submission of jobs, because the `check_str` changed. @boegel what is your opinion? Do we need to an additional check?