### PR TITLE
remove default binaries from EB test PATH

### DIFF
--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -8,11 +8,21 @@
 set -e
 
 TOPDIR="/project"
+BINDIR="$TOPDIR/bin"
+mkdir $BINDIR
+$EB_BIN = `which eb`
+export EB_PYTHON=python3
+
 
 EB_PREFIX=$HOME/easybuild
 export PYTHONPATH=$EB_PREFIX/easybuild-framework:$EB_PREFIX/easybuild-easyblocks:$EB_PREFIX/easybuild-easyconfigs
 # $HOME/.local/bin is added to $PATH for Python packages like archspec installed with 'pip install --user'
-export PATH=$EB_PREFIX/easybuild-framework:$HOME/.local/bin:$PATH
+# we include the EB strict requirements in $PATH and all other paths are removed from $PATH so builds that don't specify a dependency correctly fail
+# see https://docs.easybuild.io/en/latest/Installation.html#requirements
+ln -s `which $EB_PYTHON` $BINDIR
+ln -s `which module` $BINDIR
+
+export PATH=$EB_PREFIX/easybuild-framework:$HOME/.local/bin:$BINDIR
 
 # hardcode to haswell for now, workernodes are actually a mix of haswell/broadwell (but seems to work fine)
 export EASYBUILD_PREFIX=$TOPDIR/$USER/Rocky8/haswell
@@ -20,8 +30,6 @@ export EASYBUILD_BUILDPATH=/tmp/$USER
 export EASYBUILD_SOURCEPATH=$TOPDIR/$USER/sources:$TOPDIR/maintainers/sources
 
 export EASYBUILD_GITHUB_USER=boegelbot
-
-export EB_PYTHON=python3
 
 export EASYBUILD_ACCEPT_EULA_FOR='.*'
 
@@ -33,4 +41,4 @@ export INTEL_LICENSE_FILE=$TOPDIR/maintainers/licenses/intel.lic
 
 module use $EASYBUILD_PREFIX/modules/all
 
-eb --from-pr $EB_PR --debug --rebuild --robot --upload-test-report --download-timeout=1000 $EB_ARGS
+$EB_BIN --from-pr $EB_PR --debug --rebuild --robot --upload-test-report --download-timeout=1000 $EB_ARGS


### PR DESCRIPTION
EB tests that do not supply all dependencies currently don't fail if the system happens to have the needed tools installed by default.

only the tools mentioned here should be in the test env to catch these missing dependencies:
https://docs.easybuild.io/en/latest/Installation.html#dependencies
