### PR TITLE
implement support for testing PRs in container

### DIFF
--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -8,7 +8,7 @@
 set -e
 
 TOPDIR="/project"
-CONTAINER_BIND_PATHS="${TOPDIR}/$USER"
+CONTAINER_BIND_PATHS="${TOPDIR}/$USER:${TOPDIR}/maintainers"
 
 EB_PREFIX=${HOME}/easybuild
 export PYTHONPATH=${EB_PREFIX}/easybuild-framework:${EB_PREFIX}/easybuild-easyblocks:${EB_PREFIX}/easybuild-easyconfigs

--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -8,16 +8,18 @@
 set -e
 
 TOPDIR="/project"
+CONTAINER_BIND_PATHS="${TOPDIR}/$USER"
 
-EB_PREFIX=$HOME/easybuild
-export PYTHONPATH=$EB_PREFIX/easybuild-framework:$EB_PREFIX/easybuild-easyblocks:$EB_PREFIX/easybuild-easyconfigs
+EB_PREFIX=${HOME}/easybuild
+export PYTHONPATH=${EB_PREFIX}/easybuild-framework:${EB_PREFIX}/easybuild-easyblocks:${EB_PREFIX}/easybuild-easyconfigs
 # $HOME/.local/bin is added to $PATH for Python packages like archspec installed with 'pip install --user'
-export PATH=$EB_PREFIX/easybuild-framework:$HOME/.local/bin:$PATH
+export PATH=${EB_PREFIX}/easybuild-framework:${HOME}/.local/bin:${PATH}
 
 # hardcode to haswell for now, workernodes are actually a mix of haswell/broadwell (but seems to work fine)
-export EASYBUILD_PREFIX=$TOPDIR/$USER/Rocky8/haswell
-export EASYBUILD_BUILDPATH=/tmp/$USER
-export EASYBUILD_SOURCEPATH=$TOPDIR/$USER/sources:$TOPDIR/maintainers/sources
+export CPU_ARCH=haswell
+export EASYBUILD_PREFIX=${TOPDIR}/${USER}/Rocky8/${CPU_ARCH}
+export EASYBUILD_BUILDPATH=/tmp/${USER}
+export EASYBUILD_SOURCEPATH=${TOPDIR}/${USER}/sources:${TOPDIR}/maintainers/sources
 
 export EASYBUILD_GITHUB_USER=boegelbot
 
@@ -25,12 +27,33 @@ export EB_PYTHON=python3
 
 export EASYBUILD_ACCEPT_EULA_FOR='.*'
 
-export EASYBUILD_HOOKS=$HOME/boegelbot/eb_hooks.py
+export EASYBUILD_HOOKS=${HOME}/boegelbot/eb_hooks.py
 
 export EASYBUILD_CUDA_COMPUTE_CAPABILITIES=7.0
 
-export INTEL_LICENSE_FILE=$TOPDIR/maintainers/licenses/intel.lic
+export INTEL_LICENSE_FILE=${TOPDIR}/maintainers/licenses/intel.lic
 
-module use $EASYBUILD_PREFIX/modules/all
+module use ${EASYBUILD_PREFIX}/modules/all
 
-eb --from-pr $EB_PR --debug --rebuild --robot --upload-test-report --download-timeout=1000 $EB_ARGS
+EB_CMD="eb --from-pr ${EB_PR} --debug --rebuild --robot --upload-test-report --download-timeout=1000"
+if [ ! -z "${EB_ARGS}" ]; then
+    EB_CMD="${EB_CMD} ${EB_ARGS}"
+fi
+
+if [ -z "${EB_CONTAINER}" ]; then
+    ${EB_CMD}
+else
+    if [ ! -z "$(command -v apptainer)" ]; then
+        CONTAINER_EXEC_CMD="apptainer exec"
+    elif [ ! -z "$(command -v singularity)" ]; then
+        CONTAINER_EXEC_CMD="singularity exec"
+    else
+        echo "Neither Apptainer nor Singularity available, can't test PR ${EB_PR} in ${EB_CONTAINER} container!" >&2
+        exit 1
+    fi
+    module unuse ${EASYBUILD_PREFIX}/modules/all
+    export EASYBUILD_PREFIX=${TOPDIR}/${USER}/container-$(basename ${EB_CONTAINER})/${CPU_ARCH}
+    module use ${EASYBUILD_PREFIX}/modules/all
+
+    ${CONTAINER_EXEC_CMD} --bind ${CONTAINER_BIND_PATHS} ${EB_CONTAINER} bash -l -c "export PATH=$PATH:\$PATH; export PYTHONPATH=$PYTHONPATH:\$PYTHONPATH; module unuse $MODULEPATH; ${EB_CMD}"
+fi

--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -8,7 +8,7 @@
 set -e
 
 TOPDIR="/project"
-CONTAINER_BIND_PATHS="${TOPDIR}/$USER:${TOPDIR}/maintainers"
+CONTAINER_BIND_PATHS="--bind ${TOPDIR}/$USER --bind ${TOPDIR}/maintainers"
 
 EB_PREFIX=${HOME}/easybuild
 export PYTHONPATH=${EB_PREFIX}/easybuild-framework:${EB_PREFIX}/easybuild-easyblocks:${EB_PREFIX}/easybuild-easyconfigs
@@ -55,5 +55,5 @@ else
     export EASYBUILD_PREFIX=${TOPDIR}/${USER}/container-$(basename ${EB_CONTAINER})/${CPU_ARCH}
     module use ${EASYBUILD_PREFIX}/modules/all
 
-    ${CONTAINER_EXEC_CMD} --bind ${CONTAINER_BIND_PATHS} ${EB_CONTAINER} bash -l -c "export PATH=$PATH:\$PATH; export PYTHONPATH=$PYTHONPATH:\$PYTHONPATH; module unuse $MODULEPATH; ${EB_CMD}"
+    ${CONTAINER_EXEC_CMD} ${CONTAINER_BIND_PATHS} ${EB_CONTAINER} bash -l -c "export PATH=$PATH:\$PATH; export PYTHONPATH=$PYTHONPATH:\$PYTHONPATH; module unuse $MODULEPATH; ${EB_CMD}"
 fi

--- a/test_prs_generoso.sh
+++ b/test_prs_generoso.sh
@@ -1,1 +1,1 @@
-python3 ./boegelbot.py --mode test_pr --github-user boegelbot --owner boegel --host generoso --core-cnt 4 --pr-test-cmd "EB_PR=%(pr)s EB_ARGS=%(eb_args)s /opt/software/slurm/bin/sbatch --job-name test_PR_%(pr)s --ntasks=%(core_cnt)s ~/boegelbot/eb_from_pr_upload_generoso.sh"
+python3 ./boegelbot.py --mode test_pr --github-user boegelbot --owner boegel --host generoso --core-cnt 4 --pr-test-cmd "EB_PR=%(pr)s EB_ARGS=%(eb_args)s EB_CONTAINER=%(container)s /opt/software/slurm/bin/sbatch --job-name test_PR_%(pr)s --ntasks=%(core_cnt)s ~/boegelbot/eb_from_pr_upload_generoso.sh"


### PR DESCRIPTION
currently being tested via https://github.com/easybuilders/easybuild-easyconfigs/pull/16486#issuecomment-1291006520, seems to be working as expected after posting a comment like:

```
@boegelbot please test @ generoso in container rockylinux-9.0
```

All containers available via https://github.com/easybuilders/easybuild-containers are supported

Still WIP because need to make necessary changes to scripts for `jsc-zen2` as well...