### PR TITLE
set `$PSM3_DEVICES` as workaround for hanging MPI_Init_thread with OpenMPI 4.1.5 / libfabric 1.18.0

### DIFF
--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -31,6 +31,9 @@ export EASYBUILD_HOOKS=${HOME}/boegelbot/eb_hooks.py
 
 export EASYBUILD_CUDA_COMPUTE_CAPABILITIES=7.0
 
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/18925
+export PSM3_DEVICES='self,shm'
+
 export INTEL_LICENSE_FILE=${TOPDIR}/maintainers/licenses/intel.lic
 
 module use ${EASYBUILD_PREFIX}/modules/all


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/18925