### PR TITLE
change to use `FI_PROVIDER="^psm3"`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-latest
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - name: Checkout

--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -32,7 +32,7 @@ export EASYBUILD_HOOKS=${HOME}/boegelbot/eb_hooks.py
 export EASYBUILD_CUDA_COMPUTE_CAPABILITIES=7.0
 
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/18925
-export PSM3_DEVICES='self,shm'
+export FI_PROVIDER="^psm3"
 
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19314#issuecomment-1825665377
 export I_MPI_FABRICS=shm


### PR DESCRIPTION
and remove Python 3.6/3.7 because of https://github.com/boegel/boegelbot/actions/runs/10202271637/job/28225999147