### PR TITLE
Use builddirs unique to PR

### DIFF
--- a/eb_from_pr_upload_generoso.sh
+++ b/eb_from_pr_upload_generoso.sh
@@ -18,7 +18,7 @@ export PATH=${EB_PREFIX}/easybuild-framework:${HOME}/.local/bin:${PATH}
 # hardcode to haswell for now, workernodes are actually a mix of haswell/broadwell (but seems to work fine)
 export CPU_ARCH=haswell
 export EASYBUILD_PREFIX=${TOPDIR}/${USER}/Rocky8/${CPU_ARCH}
-export EASYBUILD_BUILDPATH=/tmp/${USER}
+export EASYBUILD_BUILDPATH=/tmp/${USER}-${EB_PR}
 export EASYBUILD_SOURCEPATH=${TOPDIR}/${USER}/sources:${TOPDIR}/maintainers/sources
 
 export EASYBUILD_GITHUB_USER=boegelbot

--- a/eb_from_pr_upload_jsc-zen2.sh
+++ b/eb_from_pr_upload_jsc-zen2.sh
@@ -17,7 +17,7 @@ export PYTHONPATH=$EB_PREFIX/easybuild-framework:$EB_PREFIX/easybuild-easyblocks
 export PATH=$EB_PREFIX/easybuild-framework:$HOME/.local/bin:$PATH
 
 export EASYBUILD_PREFIX=$TOPDIR/$USER/Rocky8/zen2
-export EASYBUILD_BUILDPATH=/tmp/$USER
+export EASYBUILD_BUILDPATH=/tmp/${USER}-${EB_PR}
 export EASYBUILD_SOURCEPATH=$TOPDIR/$USER/sources
 
 export EASYBUILD_GITHUB_USER=boegelbot

--- a/eb_from_pr_upload_jsc-zen3.sh
+++ b/eb_from_pr_upload_jsc-zen3.sh
@@ -26,7 +26,7 @@ export CPU_ARCH=$(archspec cpu)
 export OS_DISTRO=$(source /etc/os-release; echo $ID)
 export OS_VERSION=$(source /etc/os-release; echo $VERSION_ID | awk -F '.' '{print $1}')
 export EASYBUILD_PREFIX=${TOPDIR}/${USER}/${OS_DISTRO}${OS_VERSION}/${CPU_ARCH}
-export EASYBUILD_BUILDPATH=/tmp/${USER}
+export EASYBUILD_BUILDPATH=/tmp/${USER}-${EB_PR}
 export EASYBUILD_SOURCEPATH=${TOPDIR}/${USER}/sources:${TOPDIR}/maintainers/sources
 
 export EASYBUILD_GITHUB_USER=boegelbot


### PR DESCRIPTION
This avoids clashes when running multiple builds in parallel on the same node.

This might have been the cause for e.g. https://gist.github.com/boegelbot/fe22b014c1cee9a091f4a8a20d958b58