### PR TITLE
adjust mem-per-cpu on jsc-zen3

### DIFF
--- a/eb_from_pr_upload_jsc-zen3.sh
+++ b/eb_from_pr_upload_jsc-zen3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 #SBATCH --nodes 1
 #SBATCH --ntasks=4
-#SBATCH --mem-per-cpu=4000M
+#SBATCH --mem-per-cpu=3800M
 #SBATCH --time 100:0:0
 #SBATCH --partition=jsczen3c
 #SBATCH --output /project/def-maintainers/boegelbot/slurmjobs/slurm-%j.out


### PR DESCRIPTION
The compute nodes have 16 vCPU and 64 GB RAM. About 1.4 GB is needed for the OS. Let's adjust the parameter `--mem-per-cpu` to 3800M.